### PR TITLE
Corrected 'create commission' params

### DIFF
--- a/src/apiary.apib
+++ b/src/apiary.apib
@@ -660,15 +660,12 @@ Only outputs Commission offers for the specified Voucher.
 
 ### Create a Commission [POST]
 
-Create new Commission offers, you can nest multiple new Commissions within a `commissions` array. The relevant
-`commission_level` must be passed to inform the endpoint which level the Commission belongs. If the level is not
-`campaign` then the associated `reference_id` should be passed to define the entity at the chosen level.
+Create new Commission offers, you can nest multiple new Commissions within a `commissions` array
 
 + Request (application/json; charset=utf-8)
     + Attributes
         + commissions (array)
             + (Commission Base)
-                + commission_level (required)
                 + reference_id
 
 + Response 200 (application/json; charset=utf-8)
@@ -1649,12 +1646,10 @@ level `conversions` array.
 + One Of
     + commission_rate: 4
     + commission_value
-    + commission_value_cpc
 + Include Time Range
 + country (Country)
-+ vertical_id: 10 (number, required)
-+ vertical_name: Other (required)
-+ conversion_type: 10 (number, required)
++ vertical: 10 (number)
++ conversion_type: 10 (number)
 + sku
 + customer_type: new (enum)
     + new


### PR DESCRIPTION
-Removed 'commission_level' and 'commission_value_cpc'
-Removed 'vertical_id' and 'vertcal_name'
-Inserted 'vertical'parameter
