### PR TITLE
Be clear where to find application key

### DIFF
--- a/src/intro.apib
+++ b/src/intro.apib
@@ -7,6 +7,9 @@ The API supports two authentication protocols:
 ### HTTP Basic Auth
 You must have a valid `application_key` which identifies the Network you are making requests against.
 
+You can find your `application_key` & `user_api_key` in PHG Console -> Reporting tab -> Report Download Options.
+They are shown in the format `https://application_key:user_api_key@api.performancehorizon.com/...`
+
 Unless you are creating a User, you should make all requests in the context of a User account. Each User has their own
 unique `user_api_key` which must be sent in conjunction with the `application_key`.
 


### PR DESCRIPTION
In my view the documentation does not make clear where to find your application_key. As it not shown in the account dashboard it is not immediately obvious where to find it. I think this addition may help other Developers in the future.

@pete001 @performancehorizon 

